### PR TITLE
Add moist-dry conversions into the parameterisation code.

### DIFF
--- a/CAM_interface/yog_intr.F90
+++ b/CAM_interface/yog_intr.F90
@@ -198,7 +198,7 @@ subroutine yog_tend(ztodt, state, ptend)
    real(r8), pointer, dimension(:)   :: snow         ! snow
    real(r8), pointer, dimension(:,:) :: cld
 
-   real(r8) :: yog_precsfc(pcols)  ! scattered precip flux at each level
+   real(r8) :: yog_precsfc(ncols)  ! scattered precip flux at each level
 
    lchnk = state%lchnk
    ncol  = state%ncol

--- a/YOG_convection/nn_convection_flux.F90
+++ b/YOG_convection/nn_convection_flux.F90
@@ -21,7 +21,7 @@ private
 !---------------------------------------------------------------------
 ! public interfaces
 public  nn_convection_flux, nn_convection_flux_init, nn_convection_flux_finalize, &
-        esati, qsati, esatw, qsatw, dtqsatw, dtqsati
+        esati, rsati, esatw, rsatw, dtrsatw, dtrsati
 
 
 !---------------------------------------------------------------------
@@ -160,7 +160,7 @@ contains
 
         ! Other variables
         real(dp),   dimension(nrf) :: omp, fac
-        real(dp),   dimension(size(tabs_i, 2)) :: qsat, irhoadz, irhoadzdz
+        real(dp),   dimension(size(tabs_i, 2)) :: rsat, irhoadz, irhoadzdz
 
         ! -----------------------------------
         ! variables for NN
@@ -220,9 +220,9 @@ contains
             ! ! If using generalised relative humidity convert non-precip. water content to rel. hum
             !     do k=1,nzm
             !         omn = omegan(tabs(i,j,k))
-            !         qsat(k) = omn * qsatw(tabs(i,j,k),pres(k)) + (1.-omn) * qsati(tabs(i,j,k),pres(k))
+            !         rsat(k) = omn * rsatw(tabs(i,j,k),pres(k)) + (1.-omn) * rsati(tabs(i,j,k),pres(k))
             !     end do
-            !     features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,j,1:input_ver_dim)/qsat(1:input_ver_dim),4)
+            !     features(dim_counter+1:dim_counter+input_ver_dim) = real(q_i(i,j,1:input_ver_dim)/rsat(1:input_ver_dim),4)
             !     dim_counter = dim_counter + input_ver_dim
             ! else
             ! ! if using non-precipitating water as water content
@@ -425,12 +425,14 @@ contains
 
 
     !-----------------------------------------------------------------
-    ! Need qsatw functions to:
+    ! Need rsatw functions to:
     !     - run with rf_uses_rh option (currently unused)
     !     - convert variables in CAM interface
     ! Ripped from SAM model:
     ! https://github.com/yaniyuval/Neural_nework_parameterization/blob/f81f5f695297888f0bd1e0e61524590b4566bf03/sam_code_NN/sat.f90
-
+    ! Note r is used instead of q as q in CAM signifies a moist mixing ratio whilst SAM
+    ! uses dry mixing ratios.
+    !
     ! Saturation vapor pressure and mixing ratio.
     ! Based on Flatau et.al, (JAM, 1992:1507)
 
@@ -458,8 +460,8 @@ contains
     end function esatw
 
 
-    != unit 1 :: qsatw
-    real(dp) function qsatw(t,p)
+    != unit 1 :: rsatw
+    real(dp) function rsatw(t,p)
       implicit none
       != unit K :: t
       real(dp) :: t  ! temperature
@@ -469,8 +471,8 @@ contains
       real(dp) :: esat
 
       esat = esatw(t)
-      qsatw = 0.622 * esat/max(esat, p-esat)
-    end function qsatw
+      rsatw = 0.622 * esat/max(esat, p-esat)
+    end function rsatw
 
 
     real(dp) function dtesatw(t)
@@ -487,12 +489,12 @@ contains
     end function dtesatw
 
 
-    real(dp) function dtqsatw(t,p)
+    real(dp) function dtrsatw(t,p)
       implicit none
       real(dp) :: t  ! temperature (K)
       real(dp) :: p  ! pressure    (mb)
-      dtqsatw=0.622*dtesatw(t)/p
-    end function dtqsatw
+      dtrsatw=0.622*dtesatw(t)/p
+    end function dtrsatw
 
 
     real(dp) function esati(t)
@@ -510,8 +512,8 @@ contains
     end function esati
 
 
-    != unit 1 :: qsati
-    real(dp) function qsati(t,p)
+    != unit 1 :: rsati
+    real(dp) function rsati(t,p)
       implicit none
       != unit t :: K
       real(dp) :: t  ! temperature
@@ -522,8 +524,8 @@ contains
       != unit mb :: esat
       real(dp) :: esat
       esat = esati(t)
-      qsati = 0.622 * esat/max(esat,p-esat)
-    end function qsati
+      rsati = 0.622 * esat/max(esat,p-esat)
+    end function rsati
 
 
     real(dp) function dtesati(t)
@@ -541,12 +543,12 @@ contains
     end function dtesati
 
 
-    real(dp) function dtqsati(t,p)
+    real(dp) function dtrsati(t,p)
       implicit none
       real(dp) :: t  ! temperature (K)
       real(dp) :: p  ! pressure    (mb)
-      dtqsati = 0.622 * dtesati(t) / p
-    end function dtqsati
+      dtrsati = 0.622 * dtesati(t) / p
+    end function dtrsati
 
 
 end module nn_convection_flux_mod


### PR DESCRIPTION
This mirrors the code on the main CAM-ML repo that implements the mixing ratio conversions.

It also resolves a bug with an #ifdef that was preventing a test file from building.