### PR TITLE
Pull out mixing ratio conversion into functions

### DIFF
--- a/CAM_interface/nn_interface_CAM.F90
+++ b/CAM_interface/nn_interface_CAM.F90
@@ -32,6 +32,7 @@ public  nn_convection_flux_CAM, &
 public interp_to_sam, interp_to_cam
 public SAM_var_conversion, CAM_var_conversion
 public fetch_sam_data
+public calculate_dry_mixing_ratio, calculate_moist_mixing_ratio
 
 !---------------------------------------------------------------------
 ! local/private data
@@ -156,7 +157,7 @@ contains
         y_in(:) = 0.0
 
         !-----------------------------------------------------
-        
+
 #ifdef CAM_PROFILE
         call nf_write_cam(tabs_cam(1,:), "TABS_CAM_IN")
         call nf_write_cam(qi_cam(1,:), "QI_CAM_IN")
@@ -201,7 +202,7 @@ contains
         call nf_write_sam(qi_sam(1,:), "QI_SAM_IN")
         call nf_write_sam(qc_sam(1,:), "QC_SAM_IN")
         call nf_write_sam(qv_sam(1,:), "QV_SAM_IN")
-        
+
         call nf_write_cam(pres_cam(1,:), "P_CAM")
         call nf_write_sam(pres(1:nrf) * 100D0, "P_SAM")
         call nf_write_cam(pres_cam(1,:) / pres_sfc_cam(1), "PNORM_CAM")
@@ -219,7 +220,7 @@ contains
 
 #endif
         !-----------------------------------------------------
-        
+
         ! Convert CAM Moistures and tabs to SAM q and t
         call  CAM_var_conversion(qv_sam, qc_sam, qi_sam, r_sam, tabs_sam, t_sam)
 
@@ -257,7 +258,7 @@ contains
         call nf_write_scalar(precsfc_i(1), "PREC_SAM_OUT")
 #endif
         !-----------------------------------------------------
-        
+
         ! Formulate the output variables to CAM as required.
         call SAM_var_conversion(t_sam, r_sam, tabs_sam, qv_sam, qc_sam, qi_sam)
         ! Convert precipitation from kg/m^2 to m by dividing by density (1000)
@@ -315,8 +316,34 @@ contains
 
 
     !-----------------------------------------------------------------
+    subroutine calculate_dry_mixing_ratio(qv, qc, qi, r)
+        !! Calculate dry mixing ratio as required by SAM from moist variables as
+        !! provided by CAM
+        real(dp), intent(in) :: qv, qc, qi
+        real(dp), intent(out) :: r
+        real(dp) :: rv, rc, ri
+            rv = qv / (1. - qv)
+            rc = qc * (1.+rv)
+            ri = qi * (1.+rv)
+            r = rv + rc + ri
+    end subroutine
+
+    !-----------------------------------------------------------------
+    subroutine calculate_moist_mixing_ratio(rv, rn, omegan, qc, qi, qv)
+        !! Code for calculating qc and qi from rn.
+        !! Adapted from statistics.f90 in SAM assuming dokruegermicro=.false.
+        !! Also implements conversion from SAM dry mixing ratios to CAM moist mixing
+        !! ratios
+        real(dp), intent(in) :: rv, rn, omegan
+        real(dp), intent(out) :: qc, qi, qv
+        qc = rn*omegan/(1.+rv)
+        qi = rn*(1.-omegan)/(1.+rv)
+        qv = rv/(1.+rv)
+    end subroutine
+
+    !-----------------------------------------------------------------
     ! Private Subroutines
-    
+
     subroutine interp_to_sam(p_cam, p_surf_cam, var_cam, var_sam, var_cam_surface)
         !! Interpolate from the CAM pressure grid to the SAM pressure grid.
         !! Uses linear interpolation between nearest grid points on domain (CAM) grid.
@@ -380,7 +407,7 @@ contains
                 ! TODO This check is run on every iteration - move outside
                  write(*,*) "CAM upper pressure level is lower than that of SAM: Stopping."
                 stop
-            
+
             ! Locate the neighbouring CAM indices to interpolate between
             else
                 ! TODO - this will be slow - speed up later
@@ -657,11 +684,8 @@ contains
 
         do k = 1, nz
           do i = 1, nx
-            ! Calculate dry mixing ratio as required by SAM from moist variables as provided by CAM
-            rv = qv(i,k) / (1. - qv(i,k))
-            rc = qc(i,k) * (1.+rv)
-            ri = qi(i,k) * (1.+rv)
-            r(i,k) = rv + rc + ri
+            ! Calculate dry mixing ratio from moist variables
+            call calculate_dry_mixing_ratio(qv(i,k), qc(i,k), qi(i,k), r(i,k))
 
             ! omp  = max(0.,min(1.,(tabs(i,k)-tprmin)*a_pr))  ! There is no qp in CAM
             omn  = max(0.,min(1.,(tabs(i,k)-tbgmin)*a_bg))
@@ -673,7 +697,7 @@ contains
         end do
 
     end subroutine CAM_var_conversion
-    
+
 
     subroutine SAM_var_conversion(t, r, tabs, qv, qc, qi)
         !! Convert SAM t and r to tabs, qv, qc, qi used by CAM
@@ -718,7 +742,7 @@ contains
         ! This code is adapted from cloud.f90 in SAM
         do k = 1, nz
         do i = 1, nx
-        
+
             ! Enforce r >= 0.0
             r_temp=max(0.,r(i,k))
 
@@ -790,13 +814,10 @@ contains
             ! Set tabs to iterated tabs after convection
             tabs(i,k) = tabs1
 
-            ! Code for calculating qc and qi from rn.
-            ! Adapted from statistics.f90 in SAM assuming dokruegermicro=.false.
-            ! Also implements conversion from SAM dry mixing ratios to CAM moist mixing ratios
+            ! Calculating qc and qi from rn and converst from SAM dry
+            ! mixing ratios to CAM moist mixing ratios
             omn = omegan(tabs(i,k))
-            qc(i,k) = rn*omn/(1.+rv)
-            qi(i,k) = rn*(1.-omn)/(1.+rv)
-            qv(i,k) = rv/(1.+rv)
+            call calculate_moist_mixing_ratio(rv, rn, omn, qc(i,k), qi(i, k), qv(i, k))
 
         end do
         end do

--- a/CAM_interface/nn_interface_CAM.F90
+++ b/CAM_interface/nn_interface_CAM.F90
@@ -814,7 +814,7 @@ contains
             ! Set tabs to iterated tabs after convection
             tabs(i,k) = tabs1
 
-            ! Calculating qc and qi from rn and converst from SAM dry
+            ! Calculating qc and qi from rn, converting from SAM dry
             ! mixing ratios to CAM moist mixing ratios
             omn = omegan(tabs(i,k))
             call calculate_moist_mixing_ratio(rv, rn, omn, qc(i,k), qi(i, k), qv(i, k))

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Files:
 - Makefile - Makefile to compile these files
 
 Note that you will need to generate the SAM sounding (an [atmospheric sounding](https://en.wikipedia.org/wiki/Atmospheric_sounding) that defines the SAM grid that the parameterisation is operating on --
-we need this grid for the parameterisation, but also to interpolate any inputs from a different model onto this grid so that they can be used in the neural net) as a NetCDF file from the data files in `YOG_convection/rresources/` if you are using the CAM interface.\
+we need this grid for the parameterisation, but also to interpolate any inputs from a different model onto this grid so that they can be used in the neural net) as a NetCDF file from the data files in `YOG_convection/resources/` if you are using the CAM interface.\
 This can be done from within the `YOG_convection/resources/` directory as follows:
 ```
 python -m venv venv

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Files:
 - `NN_weights_YOG_convection.nc` - NetCDF file with weights for the neural net
 - Makefile - Makefile to compile these files
 
-Note that you will need to generate the SAM sounding (an [atmospheric sounding](https://en.wikipedia.org/wiki/Atmospheric_sounding) that defines the SAM grid that the parameterisation is operating on -- 
-we need this grid for the parameterisation, but also to interpolate any inputs from a different model onto this grid so that they can be used in the neural net) as a NetCDF file from the data files in `resources/` if you are using the CAM interface.\
-This can be done from within the `resources/` directory as follows:
+Note that you will need to generate the SAM sounding (an [atmospheric sounding](https://en.wikipedia.org/wiki/Atmospheric_sounding) that defines the SAM grid that the parameterisation is operating on --
+we need this grid for the parameterisation, but also to interpolate any inputs from a different model onto this grid so that they can be used in the neural net) as a NetCDF file from the data files in `YOG_convection/rresources/` if you are using the CAM interface.\
+This can be done from within the `YOG_convection/resources/` directory as follows:
 ```
 python -m venv venv
 source venv/bin/activate
@@ -65,6 +65,8 @@ python sounding_to_netcdf.py
 deactivate
 
 ```
+, with a Python version >= 3.7 and < 3.11.
+
 There are test routines associated with this code in `/tests/test_YOG_convection/`.
 Guidance on running these can be found below.
 
@@ -73,7 +75,7 @@ Guidance on running these can be found below.
 This directory contains the PyTorch versions of the neural networks used in the YOG convection parameterisation.
 
 ### ``CAM_interface/``
-The directory contains the additional files or details to interface the YOG code with the CAM atmospheric model as part of the CESM model suite. 
+The directory contains the additional files or details to interface the YOG code with the CAM atmospheric model as part of the CESM model suite.
 
 An implementation of this code within CAM, following the process outlined below, is available in the [m2lines/CAM-ML](https://github.com/m2lines/CAM-ML/tree/CAM-ML) repository.
 This contains a full description of how to install and run the code as part of the CESM model suite.
@@ -82,8 +84,8 @@ That specific implementation is run within CESM v2.1.5 and is based of a version
 There are notable future changes to the CAM source for CESM v2.2 and v3.0 that may
 require revisions to these files in future.
 
-In addition to the files in `[/YOG_convection](/YOG_convection)` containing the parameterisation,
-the additional files here are required:
+In addition to the files in [/YOG_convection](/YOG_convection) containing the parameterisation,
+this files here are required:
 
 - `nn_interface_CAM.F90` - The interface for performing conversion from CAM variables and grid into the variables/grid expected by the YOG parameterisation.
 - `yog_intr.F90` - The interface between the CAM model and the YOG parameterisation.
@@ -102,7 +104,7 @@ Guidance on running these can be found below.
 
 ### ``profile_test/``
 
-The CAM Profile Test code is a standalone test rig around the YOG convection parameterisation routines for debugging. 
+The CAM Profile Test code is a standalone test rig around the YOG convection parameterisation routines for debugging.
 
 The [README in the subdirectory](https://github.com/m2lines/convection-parameterization-in-CAM/blob/main/profile_test/README.md) contains detailed information how to run these tests.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There are notable future changes to the CAM source for CESM v2.2 and v3.0 that m
 require revisions to these files in future.
 
 In addition to the files in [/YOG_convection](/YOG_convection) containing the parameterisation,
-this files here are required:
+these files here are also required:
 
 - `nn_interface_CAM.F90` - The interface for performing conversion from CAM variables and grid into the variables/grid expected by the YOG parameterisation.
 - `yog_intr.F90` - The interface between the CAM model and the YOG parameterisation.

--- a/profile_test/README.md
+++ b/profile_test/README.md
@@ -22,7 +22,7 @@ pip install -r requirements.txt
 ```
 
 Before running the code generate the SAM sounding profiles in the `YOG_convection/resources/`
-directory as described in `YOG_convection/README.md`:
+directory as described in [the main README](https://github.com/m2lines/convection-parameterization-in-CAM/blob/main/README.md) in the Contents section about `YOG_convection/`.
 
 Then build and run the fortran code using CMake.\
 ```


### PR DESCRIPTION
Fixes #79.

This PR separates the computations of dry and moist mixing ratios into separate functions. This is to enable testing.

It also includes some small changes to the README to clarify instructions.