### PR TITLE
Updates to the variable conversion tests

### DIFF
--- a/tests/test_CAM_interface/test_cam_interface.F90
+++ b/tests/test_CAM_interface/test_cam_interface.F90
@@ -481,6 +481,7 @@ module cam_tests
       real(dp), dimension(num_cols, sam_sounding) :: t, q, tabs, qv, qc, qi
       real(dp), dimension(num_cols, sam_sounding) :: r, p_sat, q_sat
       real(dp), dimension(num_cols, sam_sounding) :: tabs_exp, qv_exp, qc_exp, qi_exp
+      real(dp), dimension(num_cols, sam_sounding) :: tabs_int, qv_int, qc_int, qi_int
       integer :: i
       real(dp), dimension(sam_sounding) :: pres_sam, presi_sam, gamaz_sam, rho_sam, z_sam
 
@@ -521,6 +522,11 @@ module cam_tests
       qi_exp = qi
 
       call CAM_var_conversion(qv, qc, qi, q, tabs, t)
+      ! Store intermediates after CAM conversion
+      qv_int = qv
+      qc_int = qc
+      qi_int = qi
+      tabs_int = tabs
       call SAM_var_conversion(t, q, tabs, qv, qc, qi)
 
       ! Note: in the assertions,
@@ -531,6 +537,14 @@ module cam_tests
       call assert_array_equal(qv, qv_exp, test_name//": qv")
       call assert_array_equal(qc+1.0, qc_exp+1.0, test_name//": qc")
       call assert_array_equal(qi+1.0, qi_exp+1.0, test_name//": qi")
+
+      ! Convert SAM->CAM one last time, i.e., is the conversion invertible
+      call CAM_var_conversion(qv, qc, qi, q, tabs, t)
+
+      call assert_array_equal(tabs, tabs_int, test_name//": tabs")
+      call assert_array_equal(qv, qv_int, test_name//": qv")
+      call assert_array_equal(qc+1.0, qc_int+1.0, test_name//": qc")
+      call assert_array_equal(qi+1.0, qi_int+1.0, test_name//": qi")
 
     end subroutine test_rev_var_conv_moist
 


### PR DESCRIPTION
This PR has fixes for variable conversion tests
- [x] Calculated of `qv` expected values: https://github.com/m2lines/convection-parameterization-in-CAM/issues/85
- [x] An example of checking that `CAM->SAM` has a (weak) left inverse (i.e., by checking that CAM->SAM->CAM->SAM is then same as just CAM->SAM): https://github.com/m2lines/convection-parameterization-in-CAM/issues/86