### PR TITLE
Adds additional unit-of-measure (dimensionality) specifications 

### DIFF
--- a/YOG_convection/nn_convection_flux.F90
+++ b/YOG_convection/nn_convection_flux.F90
@@ -160,6 +160,9 @@ contains
 
         ! Other variables
         real(dp),   dimension(nrf) :: omp, fac
+
+        != unit s m**3 / kg  :: irhoadz
+        != unit s m**2 / kg  :: irhoadzdz
         real(dp),   dimension(size(tabs_i, 2)) :: rsat, irhoadz, irhoadzdz
 
         ! -----------------------------------


### PR DESCRIPTION
* [x] Give units of intermediates: irhoadz, irhoadzdz:

Analysis from the [calculation of these values](https://github.com/m2lines/convection-parameterization-in-CAM/blob/main/YOG_convection/nn_convection_flux.F90#L185-L186):

Since we have: 
```
        != unit (kg / m**3) :: rho
        real(dp), intent(in) :: rho(:)
            !! air density at pressure levels
...
        != unit 1 :: adz
        real(dp), intent(in) :: adz(:)
            !! ratio of the pressure level grid height spacing [m] to dz (lowest dz spacing)
```
then
```
irhoadz(k) = dtn/(rho(k)*adz(k)) !  Temporary factor for below
```
implies that `irhoadz` has unit `s / ((kg / m**3) * 1)` = `s m**3 / kg` and
```
irhoadzdz(k) = irhoadz(k)/dz 
```
implies that `irhoadzdz` has unit `s m**2 / kg`